### PR TITLE
fix: fix so the sdk doesnt thrown when a request returns new props

### DIFF
--- a/basistheory/model_utils.py
+++ b/basistheory/model_utils.py
@@ -131,11 +131,7 @@ class OpenApiModel(object):
         if name in self.openapi_types:
             required_types_mixed = self.openapi_types[name]
         elif self.additional_properties_type is None:
-            raise ApiAttributeError(
-                "{0} has no attribute '{1}'".format(
-                    type(self).__name__, name),
-                path_to_item
-            )
+            return # ignore new properties as we don't know the correct type to deserialize
         elif self.additional_properties_type is not None:
             required_types_mixed = self.additional_properties_type
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Makes so the SDK will just swallow unknown properties from an endpoint instead of throwing error

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- Can try out w/ `/tokens` calls, since that's the one that has the new prop now.
- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change