### PR TITLE
fix: Stop building .egg files that PyPI rejects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
       
       - name: "Install additional dependencies"
         run: if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      
-      - name: "Install the package"
-        run: python3 setup.py install
 
       - name: "Build"
         run: python3 setup.py sdist bdist_wheel


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Removes the step from the release process that builds a .egg file. PyPI no longer accepts .egg files as of August 1 2023 - see [this announcement](https://blog.pypi.org/posts/2023-06-26-deprecate-egg-uploads/)

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [x] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change