### PR TITLE
ENG-7852: Merging create and delete tenant invitations in the same tests 

### DIFF
--- a/integration-tests/test_tenants.py
+++ b/integration-tests/test_tenants.py
@@ -66,7 +66,8 @@ def test_get_members():
 
 #     assert tenant_report.token_report is not None
 
-def test_create_invitation():
+
+def test_create_delete_invitation():
     request = CreateTenantInvitationRequest(email="test@basistheory.com")
 
     invitation = tenants_client.create_invitation(create_tenant_invitation_request=request)
@@ -78,12 +79,6 @@ def test_create_invitation():
     assert invitation.created_by is not None
     assert invitation.created_at is not None
     assert invitation.expires_at is not None
-
-
-def test_delete_invitation():
-    request = CreateTenantInvitationRequest(email="test@basistheory.com")
-
-    invitation = tenants_client.create_invitation(create_tenant_invitation_request=request)
 
     tenants_client.delete_invitation(invitation_id=invitation.id)
 


### PR DESCRIPTION
https://linear.app/basis-theory/issue/ENG-7852/update-create-test-tenant-to-create-and-delete-invitations-in-the-same
## Description
This allows us to test the creation and also remove the created new invitations now that we have limits on the invitation requests; this helps to have new invitations hanging around without usage and increasing the invitation limit

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change